### PR TITLE
Makefile: Fix "u-boot" target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ $(U_CONFIG_H): u-boot-sunxi/.git
 	$(Q)$(MAKE) -C u-boot-sunxi $(UBOOT_CONFIG)_config O=$(U_O_PATH) CROSS_COMPILE=$(CROSS_COMPILE) -j$J
 
 u-boot: $(U_CONFIG_H)
-	$(Q)$(MAKE) -C u-boot-sunxi all O=$(U_O_PATH) CROSS_COMPILE=$(CROSS_COMPILE) -j$J
+	$(Q)$(MAKE) -C u-boot-sunxi $(BOARD) O=$(U_O_PATH) CROSS_COMPILE=$(CROSS_COMPILE) -j$J
 
 ## linux
 $(K_DOT_CONFIG): linux-sunxi/.git


### PR DESCRIPTION
"make u-boot" (for cubietruck) failed on my debian. not doing a "make all" in u-boot seems to fix this.
